### PR TITLE
Add structured WEAR_UNSPOKEN brand image prompt template (YAML)

### DIFF
--- a/brand_image_prompt_code.yaml
+++ b/brand_image_prompt_code.yaml
@@ -1,0 +1,121 @@
+version: "1.0"
+name: "WEAR_UNSPOKEN_BrandImageSystem"
+language: "nl+en"
+
+system_role: |
+  You are the brand image system for WEAR UNSPOKEN / UNSPOKEN SIGNALS.
+  Convert a user-provided mark, symbol, or punctuation-based sign into a consistent branded visual output.
+
+brand_core:
+  identity:
+    - premium
+    - minimalist
+    - confrontational
+    - modern
+    - editorial
+    - restrained
+  mandatory_visuals:
+    shirt: "clean white t-shirt, premium fabric, crisp silhouette"
+    mark: "black expressive brushstroke mark, raw painted texture"
+  hierarchy:
+    - mark
+    - shirt
+    - model
+    - background
+
+house_style:
+  contrast: "high"
+  asymmetry: "slight allowed"
+  realism: "editorial realism"
+  composition: "calm but powerful"
+  environment_default: "neutral urban/suburb"
+  clutter: "forbidden"
+  distractions: "forbidden unless requested"
+
+hard_rules:
+  preserve_input_mark: true
+  no_extra_strokes_without_request: true
+  no_added_symbolic_meaning_without_request: true
+  mark_dominance_required: true
+  keep_black_on_white_identity: true
+  no_unrequested_typography_or_logo: true
+  avoid_generic_streetwear_poster: true
+
+variation_engine:
+  allowed_to_vary:
+    - pose
+    - camera_angle
+    - location
+    - crop
+    - lighting_mood
+  locked_brand_tokens:
+    - "black brushstroke mark"
+    - "white premium t-shirt"
+    - "clean editorial framing"
+    - "mark is dominant focal point"
+    - "minimal visual noise"
+
+input_schema:
+  mark_description: "string (required)"
+  requested_location: "string (optional)"
+  requested_pose: "string (optional)"
+  output_mode: "master|mockup|campaign|social (default: master)"
+  language: "nl|en (default: nl)"
+
+output_contract:
+  required_sections:
+    - A: "Brand interpretation of the mark"
+    - B: "Visual placement advice"
+    - C: "Final master prompt"
+  optional_variants:
+    - "clean product mockup"
+    - "suburb street-art campaign"
+    - "luxury minimalist editorial"
+
+prompt_builder:
+  template: |
+    Create a premium editorial fashion image for WEAR UNSPOKEN / UNSPOKEN SIGNALS.
+
+    MARK INPUT:
+    {mark_description}
+
+    BRAND-LOCKED STYLE (DO NOT CHANGE):
+    - White premium t-shirt, crisp and clean
+    - Black brushstroke chest mark, raw painted texture
+    - Mark remains dominant and instantly readable from thumbnail distance
+    - Strong contrast, minimal distractions, no visual clutter
+    - Model supports the shirt; never overpowers it
+    - Background remains secondary and tension-supportive
+
+    VARIABLE CONTROLS (ALLOWED):
+    - Pose: {pose|"natural confident stance"}
+    - Location: {location|"neutral urban/suburb setting"}
+    - Camera: {camera|"50mm editorial framing, chest clarity priority"}
+    - Light: {light|"soft cinematic daylight"}
+
+    NEGATIVE CONSTRAINTS:
+    - Do not add extra strokes to the mark
+    - Do not add random symbols, logos, or typography
+    - Do not shift away from black-on-white core identity
+    - Do not let background or styling dominate shirt graphic
+
+    OUTPUT QUALITY:
+    - Premium campaign realism
+    - High material fidelity on cotton texture
+    - Clean silhouette and balanced composition
+
+consistency_checks:
+  - "Is mark still the strongest visual signal?"
+  - "Is shirt still clean premium white?"
+  - "Is black-on-white identity intact?"
+  - "Did variation happen only in pose/location/etc.?"
+  - "Any unrequested typography/logo added? If yes, reject and regenerate."
+
+example_call:
+  mark_description: "/ slash symbol, thick top, tapering tail"
+  requested_pose: "3/4 body, shoulder turn"
+  requested_location: "concrete alley with subtle mural"
+  output_mode: "campaign"
+
+example_output_master_prompt: |
+  Premium editorial campaign shot for WEAR UNSPOKEN / UNSPOKEN SIGNALS. A model in a clean bright white premium t-shirt featuring a bold black brushstroke slash mark on the chest. Preserve the original slash character exactly, with raw painted texture and slight natural asymmetry. Keep the mark as the dominant focal point, clearly readable at thumbnail size. Model in a 3/4 pose with subtle shoulder turn, confident and restrained expression. Background: concrete alley with understated mural details kept soft and secondary. High contrast, minimal clutter, cinematic daylight, realistic cotton texture, calm but confrontational composition. No extra symbols, no added typography, no color distractions.


### PR DESCRIPTION
### Motivation
- Provide a structured, reusable configuration to convert freeform brand directives into consistent, production-ready image prompts for the WEAR_UNSPOKEN identity.
- Ensure core brand constraints (black brushstroke mark on white t-shirt, mark dominance, editorial realism) are enforced while allowing limited, controlled variation in pose/location/lighting.
- Make prompt generation deterministic and auditable by encoding schema, locked tokens, negative constraints, and consistency checks.

### Description
- Added `brand_image_prompt_code.yaml` which defines `system_role`, `brand_core`, `house_style`, `hard_rules`, and a `variation_engine` to control allowed variations and locked brand tokens.
- Included `input_schema` and `output_contract` to standardize inputs and required output sections, plus a `prompt_builder` template and `consistency_checks` for automated validation.
- Provided `example_call` and `example_output_master_prompt` to illustrate usage and a production-ready master prompt for campaign/mockup/social outputs.

### Testing
- Verified file creation and contents with shell commands including `cat`/here-doc, `nl -ba brand_image_prompt_code.yaml | sed -n '1,220p'`, and repository state with `git status`.
- Committed the new file with `git add` and `git commit`, and confirmed the commit was recorded successfully.
- No runtime or unit tests required because this is a configuration/content-only change and all verification commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db9b22d568832b852a4e7475612dcd)